### PR TITLE
Fix formatting for the Base UI brand

### DIFF
--- a/src/app/content/legal/code.md
+++ b/src/app/content/legal/code.md
@@ -42,8 +42,8 @@ Don’t assume access to another add-on’s data or functionality unless explici
 ---
 
 ## 🎨 UI & Styling
-- **BaseUI Only**
-Official add-ons should use [BaseUI](https://base-ui.com/react/overview/quick-start) as the primary component library. Avoid mixing multiple UI kits.
+- **Base UI Only**
+Official add-ons should use [Base UI](https://base-ui.com/react/overview/quick-start) as the primary component library. Avoid mixing multiple UI kits.
 - **Custom Styling with Tailwind v4**
 Use [Tailwind’s @layer](https://tailwindcss.com/) to inject custom styles. Avoid inline styles unless necessary.
 - **Keep UI Optional**


### PR DESCRIPTION
The issue:

<img width="700" height="260" alt="SCR-20250825-bjju" src="https://github.com/user-attachments/assets/4d101372-023a-4c6f-b1f8-3c68a9cac51a" />

https://shareware.dev/legal/code#-ui-x26-styling